### PR TITLE
create url method for catch all rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org/).
 In order to read more about upgrading and BC breaks have a look at the [UPGRADE Document](UPGRADE.md).
 
+## 3.1.2 (22. April 2020)
+
++ [#]() Fix issue when creating url for `cms/default/index` route (which is the cms catch all rule).
+
 ## 3.1.1 (21. April 2020)
 
 + [#254](https://github.com/luyadev/luya-module-cms/issues/254) Fixed #254 utf8mb4 charset max key length is 767 bytes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ In order to read more about upgrading and BC breaks have a look at the [UPGRADE 
 
 ## 3.1.2 (22. April 2020)
 
-+ [#]() Fix issue when creating url for `cms/default/index` route (which is the cms catch all rule).
++ [#256](https://github.com/luyadev/luya-module-cms/pull/256) Fix issue when creating url for `cms/default/index` route (which is the cms catch all rule).
 
 ## 3.1.1 (21. April 2020)
 

--- a/src/frontend/components/CatchAllUrlRule.php
+++ b/src/frontend/components/CatchAllUrlRule.php
@@ -55,7 +55,7 @@ class CatchAllUrlRule extends UrlRule
         }
         
         // return the custom route
-        return ['/cms/default/index', ['path' => $request->pathInfo]];
+        return [$this->route, ['path' => $request->pathInfo]];
     }
 
     /**
@@ -63,7 +63,7 @@ class CatchAllUrlRule extends UrlRule
      */
     public function createUrl($manager, $route, $params)
     {
-        if (ltrim($route, '/') !== 'cms/default/index') {
+        if (ltrim($route, '/') !== $this->route) {
             $this->createStatus = self::CREATE_STATUS_ROUTE_MISMATCH;
             return false;
         }

--- a/src/frontend/components/CatchAllUrlRule.php
+++ b/src/frontend/components/CatchAllUrlRule.php
@@ -56,4 +56,13 @@ class CatchAllUrlRule extends UrlRule
         // return the custom route
         return ['/cms/default/index', ['path' => $request->pathInfo]];
     }
+
+    public function createUrl($manager, $route, $params)
+    {
+        if (!isset($params['path']) || empty($params['path'])) {
+            return false;
+        }
+
+        return '/'.$manager->composition->prependTo($params['path']);
+    }
 }

--- a/src/frontend/components/CatchAllUrlRule.php
+++ b/src/frontend/components/CatchAllUrlRule.php
@@ -2,6 +2,7 @@
 
 namespace luya\cms\frontend\components;
 
+use luya\helpers\ArrayHelper;
 use Yii;
 use luya\web\UrlRule;
 
@@ -57,12 +58,21 @@ class CatchAllUrlRule extends UrlRule
         return ['/cms/default/index', ['path' => $request->pathInfo]];
     }
 
+    /**
+     * @inheritdoc
+     */
     public function createUrl($manager, $route, $params)
     {
         if (!isset($params['path']) || empty($params['path'])) {
             return false;
         }
 
-        return '/'.$manager->composition->prependTo($params['path']);
+        $path = ArrayHelper::remove($params, 'path');
+
+        if (empty($params)) {
+            return $path;
+        }
+
+        return $path .'?'.http_build_query($params);
     }
 }

--- a/src/frontend/components/CatchAllUrlRule.php
+++ b/src/frontend/components/CatchAllUrlRule.php
@@ -63,7 +63,13 @@ class CatchAllUrlRule extends UrlRule
      */
     public function createUrl($manager, $route, $params)
     {
+        if (ltrim($route, '/') !== 'cms/default/index') {
+            $this->createStatus = self::CREATE_STATUS_ROUTE_MISMATCH;
+            return false;
+        }
+        
         if (!isset($params['path']) || empty($params['path'])) {
+            $this->createStatus = self::CREATE_STATUS_PARAMS_MISMATCH;
             return false;
         }
 

--- a/tests/src/frontend/components/CatchAllUrlRuleTest.php
+++ b/tests/src/frontend/components/CatchAllUrlRuleTest.php
@@ -11,7 +11,12 @@ class CatchAllUrlRuleTest extends CmsFrontendTestCase
     {
         $rule = new CatchAllUrlRule();
 
+        $this->assertFalse($rule->createUrl($this->app->urlManager, '/cms/default/index/', ['path' => 'foo/bar']));
+        $this->assertFalse($rule->createUrl($this->app->urlManager, '/wrong/route', ['path' => 'foo/bar']));
+        $this->assertFalse($rule->createUrl($this->app->urlManager, 'cms/default/index', []));
+
         $this->assertSame('foo/bar', $rule->createUrl($this->app->urlManager, 'cms/default/index', ['path' => 'foo/bar']));
+        $this->assertSame('foo/bar', $rule->createUrl($this->app->urlManager, '/cms/default/index', ['path' => 'foo/bar']));
         $this->assertSame('foo/bar?page=1', $rule->createUrl($this->app->urlManager, 'cms/default/index', ['path' => 'foo/bar', 'page' => 1]));
     }
 

--- a/tests/src/frontend/components/CatchAllUrlRuleTest.php
+++ b/tests/src/frontend/components/CatchAllUrlRuleTest.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace cmstests\src\frontend\components;
+
+use cmstests\CmsFrontendTestCase;
+use luya\cms\frontend\components\CatchAllUrlRule;
+
+class CatchAllUrlRuleTest extends CmsFrontendTestCase
+{
+    public function testCreateUrl()
+    {
+        $rule = new CatchAllUrlRule();
+
+        $this->assertSame('foo/bar', $rule->createUrl($this->app->urlManager, 'cms/default/index', ['path' => 'foo/bar']));
+        $this->assertSame('foo/bar?page=1', $rule->createUrl($this->app->urlManager, 'cms/default/index', ['path' => 'foo/bar', 'page' => 1]));
+    }
+
+    public function testParseRequest()
+    {
+        $rule = new CatchAllUrlRule();
+
+        $this->assertFalse($rule->parseRequest($this->app->urlManager, $this->app->request));
+    }
+
+}

--- a/tests/src/frontend/components/CatchAllUrlRuleTest.php
+++ b/tests/src/frontend/components/CatchAllUrlRuleTest.php
@@ -25,6 +25,12 @@ class CatchAllUrlRuleTest extends CmsFrontendTestCase
         $rule = new CatchAllUrlRule();
 
         $this->assertFalse($rule->parseRequest($this->app->urlManager, $this->app->request));
+
+        $this->app->request->pathInfo = 'foo/bar';
+        $this->assertSame([
+            'cms/default/index',
+            ['path' => 'foo/bar'],
+        ], $rule->parseRequest($this->app->urlManager, $this->app->request));
     }
 
 }


### PR DESCRIPTION
Enable the option to generate route with `['cms/default/index', 'path' => 'the/path/to/display']`.