### PR TITLE
catch not found exception for redirect task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org/).
 In order to read more about upgrading and BC breaks have a look at the [UPGRADE Document](UPGRADE.md).
 
+## 3.3.1 ()
+
++ [#270](https://github.com/luyadev/luya-module-cms/pull/270) Fixed a bug where CMS redirects does not work due to full page cache throws a not found exception.
+
 ## 3.3.0 (11. June 2020)
 
 + [#266](https://github.com/luyadev/luya-module-cms/issues/266) Fixed a bug where page copy should throw an error but does not.

--- a/src/frontend/controllers/DefaultController.php
+++ b/src/frontend/controllers/DefaultController.php
@@ -46,12 +46,18 @@ class DefaultController extends Controller
      */
     private function isFullPageCacheEnabled()
     {
-        return $this->module->fullPageCache 
-            && Yii::$app->request->isGet 
-            && Yii::$app->menu->current
-            && Yii::$app->menu->current->type == NavItem::TYPE_PAGE
-            && !Yii::$app->menu->current->is404Page
-            && (int) NavItem::find()->where(['nav_id' => Yii::$app->menu->current->navId, 'lang_id' => Yii::$app->adminLanguage->activeId])->select(['is_cacheable'])->scalar();
+        // if the page could not be found, caching is disable otherwise the behaviors method would
+        // throw an exception which then would stop execute the "find redirects" task.
+        try {
+            return $this->module->fullPageCache 
+                && Yii::$app->request->isGet 
+                && Yii::$app->menu->current
+                && Yii::$app->menu->current->type == NavItem::TYPE_PAGE
+                && !Yii::$app->menu->current->is404Page
+                && (int) NavItem::find()->where(['nav_id' => Yii::$app->menu->current->navId, 'lang_id' => Yii::$app->adminLanguage->activeId])->select(['is_cacheable'])->scalar();
+        } catch (NotFoundHttpException $notFound) {
+            return false;
+        }
     }
 
     /**


### PR DESCRIPTION
Fix an issue where LUYA CMS redirects won't work due to a previous not found exception throw by the cms menu component.