### PR TITLE
redirect wildcard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ In order to read more about upgrading and BC breaks have a look at the [UPGRADE 
 + [#314](https://github.com/luyadev/luya-module-cms/pull/314) Do not serve the blocks from the cache when an adminuser is logged in.
 + [#309](https://github.com/luyadev/luya-module-cms/pull/309) Added new help information for page properties as tooltip.
 + [#310](https://github.com/luyadev/luya-module-cms/issues/310) Fixed a bug where full page cache could cache the content including the LUYA Toolbar.
++ []() Add the option to use the defined wildcard value in redirects for the target. From path `foo/*` to destionation `luya.io?path=*`. The given example would redirect `foo/hello-world` to `luya.io?path=hello-word`.
 
 ## 3.4.0 (24. October 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ In order to read more about upgrading and BC breaks have a look at the [UPGRADE 
 + [#314](https://github.com/luyadev/luya-module-cms/pull/314) Do not serve the blocks from the cache when an adminuser is logged in.
 + [#309](https://github.com/luyadev/luya-module-cms/pull/309) Added new help information for page properties as tooltip.
 + [#310](https://github.com/luyadev/luya-module-cms/issues/310) Fixed a bug where full page cache could cache the content including the LUYA Toolbar.
-+ []() Add the option to use the defined wildcard value in redirects for the target. From path `foo/*` to destionation `luya.io?path=*`. The given example would redirect `foo/hello-world` to `luya.io?path=hello-word`.
++ [#317](https://github.com/luyadev/luya-module-cms/pull/317) Add the option to use the defined wildcard value in redirects for the target. From path `foo/*` to destination `luya.io?path=*`. The given example would redirect `foo/hello-world` to `luya.io?path=hello-word`.
 
 ## 3.4.0 (24. October 2020)
 

--- a/src/admin/messages/de/cmsadmin.php
+++ b/src/admin/messages/de/cmsadmin.php
@@ -208,7 +208,7 @@ return [
     'redirect_model_atr_catch_path_hint' => 'Der Pfad, von dem weitergeleitet werden soll. Sollen auch alle Unterpfade weitergeleitet werden, kannst du die Wildcard * verwenden, z.B. /blog*, um alle Unterpfade von /blog weiterzuleiten.',
     'redirect_model_atr_catch_path_error' => 'Der Pfad muss mit einem Slash / beginnen.',
     'redirect_model_atr_redirect_path' => 'Ziel',
-    'redirect_model_atr_redirect_path_hint' => 'Du kannst entweder einen absoluten Pfad verwenden, der mit https:// oder http:// beginnt, einen relativen Pfad zum Startverzeichnis der Website, der mit / beginnt, oder einen relativen Pfad zum Pfad, von dem weitergeleitet wird (z.B. wartung, um von /shop/start nach /shop/wartung weiterzuleiten).',
+    'redirect_model_atr_redirect_path_hint' => 'Du kannst entweder einen absoluten Pfad verwenden, der mit https:// oder http:// beginnt, einen relativen Pfad zum Startverzeichnis der Website, der mit / beginnt, oder einen relativen Pfad zum Pfad, von dem weitergeleitet wird (z.B. wartung, um von /shop/start nach /shop/wartung weiterzuleiten). Wenn eine Wildcard * verwendet wird im Ausgangspfad kann dieser auch als Ziel verwendet werden.',
     'redirect_model_atr_redirect_status_code' => 'HTTP-Status-Code',
     'redirect_model_atr_redirect_status_code_hint' => 'Art der Weiterleitung. Bei der Verwendung von 301: Moved Permanently werden Browser die Weiterleitung im Cache speichern, so dass Änderungen des Ziels erst nach dem Löschen des Browser-Caches wirksam werden.',
     'redirect_model_atr_redirect_status_code_opt_301' => '301: Moved Permanently',

--- a/src/admin/messages/en/cmsadmin.php
+++ b/src/admin/messages/en/cmsadmin.php
@@ -209,7 +209,7 @@ return [
     'redirect_model_atr_catch_path_hint' => 'The path which should be redirected from. If you want to match all subpaths of a path, you can use the * wildcard like in /blog*, which will match every subpath of /blog.',
     'redirect_model_atr_catch_path_error' => 'The path must start with a slash.',
     'redirect_model_atr_redirect_path' => 'Destination',
-    'redirect_model_atr_redirect_path_hint' => 'You can either use an abolute path starting with https:// or http://, a path relative to the website root starting with / or a path relative to the path that is redirected from (e.g. maintenance to redirect from /shop/start to /shop/maintenance).',
+    'redirect_model_atr_redirect_path_hint' => 'You can either use an abolute path starting with https:// or http://, a path relative to the website root starting with / or a path relative to the path that is redirected from (e.g. maintenance to redirect from /shop/start to /shop/maintenance).  Its possible to use the wildcard value from the From path, if defined.',
     'redirect_model_atr_redirect_status_code' => 'HTTP status code',
     'redirect_model_atr_redirect_status_code_hint' => 'Redirection type. When using 301: Moved Permanently, browsers will cache the redirection so that changes to the destination might not take effect without clearing the browser\'s cache.',
     'redirect_model_atr_redirect_status_code_opt_301' => '301: Moved Permanently',

--- a/src/admin/messages/fa/cmsadmin.php
+++ b/src/admin/messages/fa/cmsadmin.php
@@ -197,7 +197,7 @@ return [
     'redirect_model_atr_catch_path_hint' => 'The path which should be redirected from. If you want to match all subpaths of a path, you can use the * wildcard like in /blog*, which will match every subpath of /blog.',
     'redirect_model_atr_catch_path_error' => 'The path must start with a slash.',
     'redirect_model_atr_redirect_path' => 'مقصد',
-    'redirect_model_atr_redirect_path_hint' => 'You can either use an abolute path starting with https:// or http://, a path relative to the website root starting with / or a path relative to the path that is redirected from (e.g. maintenance to redirect from /shop/start to /shop/maintenance).',
+    'redirect_model_atr_redirect_path_hint' => 'You can either use an abolute path starting with https:// or http://, a path relative to the website root starting with / or a path relative to the path that is redirected from (e.g. maintenance to redirect from /shop/start to /shop/maintenance).  Its possible to use the wildcard value from the From path, if defined.',
     'redirect_model_atr_redirect_status_code' => 'HTTP status code',
     'redirect_model_atr_redirect_status_code_hint' => 'Redirection type. When using 301: Moved Permanently, browsers will cache the redirection so that changes to the destination might not take effect without clearing the browser\'s cache.',
     'redirect_model_atr_redirect_status_code_opt_301' => '301: Moved Permanently',

--- a/src/admin/messages/it/cmsadmin.php
+++ b/src/admin/messages/it/cmsadmin.php
@@ -198,7 +198,7 @@ return [
     'redirect_model_atr_catch_path_hint' => 'The path which should be redirected from. If you want to match all subpaths of a path, you can use the * wildcard like in /blog*, which will match every subpath of /blog.',
     'redirect_model_atr_catch_path_error' => 'The path must start with a slash.',
     'redirect_model_atr_redirect_path' => 'Destination',
-    'redirect_model_atr_redirect_path_hint' => 'You can either use an abolute path starting with https:// or http://, a path relative to the website root starting with / or a path relative to the path that is redirected from (e.g. maintenance to redirect from /shop/start to /shop/maintenance).',
+    'redirect_model_atr_redirect_path_hint' => 'You can either use an abolute path starting with https:// or http://, a path relative to the website root starting with / or a path relative to the path that is redirected from (e.g. maintenance to redirect from /shop/start to /shop/maintenance).  Its possible to use the wildcard value from the From path, if defined.',
     'redirect_model_atr_redirect_status_code' => 'HTTP status code',
     'redirect_model_atr_redirect_status_code_hint' => 'Redirection type. When using 301: Moved Permanently, browsers will cache the redirection so that changes to the destination might not take effect without clearing the browser\'s cache.',
     'redirect_model_atr_redirect_status_code_opt_301' => '301: Moved Permanently',

--- a/src/admin/messages/ua/cmsadmin.php
+++ b/src/admin/messages/ua/cmsadmin.php
@@ -210,7 +210,7 @@ return [
     'redirect_model_atr_catch_path_hint' => 'The path which should be redirected from. If you want to match all subpaths of a path, you can use the * wildcard like in /blog*, which will match every subpath of /blog.',
     'redirect_model_atr_catch_path_error' => 'The path must start with a slash.',
     'redirect_model_atr_redirect_path' => 'Destination',
-    'redirect_model_atr_redirect_path_hint' => 'You can either use an abolute path starting with https:// or http://, a path relative to the website root starting with / or a path relative to the path that is redirected from (e.g. maintenance to redirect from /shop/start to /shop/maintenance).',
+    'redirect_model_atr_redirect_path_hint' => 'You can either use an abolute path starting with https:// or http://, a path relative to the website root starting with / or a path relative to the path that is redirected from (e.g. maintenance to redirect from /shop/start to /shop/maintenance).  Its possible to use the wildcard value from the From path, if defined.',
     'redirect_model_atr_redirect_status_code' => 'HTTP status code',
     'redirect_model_atr_redirect_status_code_hint' => 'Redirection type. When using 301: Moved Permanently, browsers will cache the redirection so that changes to the destination might not take effect without clearing the browser\'s cache.',
     'redirect_model_atr_redirect_status_code_opt_301' => '301: Moved Permanently',

--- a/src/admin/messages/vi/cmsadmin.php
+++ b/src/admin/messages/vi/cmsadmin.php
@@ -210,7 +210,7 @@ return [
     'redirect_model_atr_catch_path_hint' => 'The path which should be redirected from. If you want to match all subpaths of a path, you can use the * wildcard like in /blog*, which will match every subpath of /blog.',
     'redirect_model_atr_catch_path_error' => 'The path must start with a slash.',
     'redirect_model_atr_redirect_path' => 'Destination',
-    'redirect_model_atr_redirect_path_hint' => 'You can either use an abolute path starting with https:// or http://, a path relative to the website root starting with / or a path relative to the path that is redirected from (e.g. maintenance to redirect from /shop/start to /shop/maintenance).',
+    'redirect_model_atr_redirect_path_hint' => 'You can either use an abolute path starting with https:// or http://, a path relative to the website root starting with / or a path relative to the path that is redirected from (e.g. maintenance to redirect from /shop/start to /shop/maintenance).  Its possible to use the wildcard value from the From path, if defined.',
     'redirect_model_atr_redirect_status_code' => 'HTTP status code',
     'redirect_model_atr_redirect_status_code_hint' => 'Redirection type. When using 301: Moved Permanently, browsers will cache the redirection so that changes to the destination might not take effect without clearing the browser\'s cache.',
     'redirect_model_atr_redirect_status_code_opt_301' => '301: Moved Permanently',

--- a/src/frontend/controllers/DefaultController.php
+++ b/src/frontend/controllers/DefaultController.php
@@ -157,15 +157,15 @@ class DefaultController extends Controller
         $path = Yii::$app->request->pathInfo;
         $compositePath = Yii::$app->composition->prependTo($path);
         foreach (Redirect::find()->all() as $redirect) {
-            if ($redirect->matchRequestPath($path)) {
-                return $this->redirect($redirect->getRedirectUrl(), $redirect->redirect_status_code);
+            if ($wildcard = $redirect->matchRequestPath($path)) {
+                return $this->redirect($redirect->getRedirectUrl($wildcard), $redirect->redirect_status_code);
             }
 
             // if its a multi linguage website and the language has not been omited form request path compare this version too.
             // this is requred since the luya UrlManager can change the pathInfo
             if ($path !== $compositePath) {
-                if ($redirect->matchRequestPath($compositePath)) {
-                    return $this->redirect($redirect->getRedirectUrl(), $redirect->redirect_status_code);
+                if ($wildcard = $redirect->matchRequestPath($compositePath)) {
+                    return $this->redirect($redirect->getRedirectUrl($wildcard), $redirect->redirect_status_code);
                 }
             }
         }

--- a/src/models/Redirect.php
+++ b/src/models/Redirect.php
@@ -2,6 +2,7 @@
 
 namespace luya\cms\models;
 
+use luya\admin\buttons\DuplicateActiveButton;
 use Yii;
 use luya\admin\ngrest\base\NgRestModel;
 use luya\helpers\StringHelper;
@@ -125,21 +126,35 @@ class Redirect extends NgRestModel
             ['delete', true],
         ];
     }
+
+    /**
+     * @inheritdoc
+     */
+    public function ngRestActiveButtons()
+    {
+        return [
+            [
+                'class' => DuplicateActiveButton::class,
+            ]
+        ];
+    }
     
     /**
      * Match Request Path against catch_path.
      *
      * Several version of the request path will be checked in order to ensure different siutations can be handled.
+     * 
+     * `foo/*` catch_path would return `bar` when the request path is `foo/bar`.
      *
-     * @param string $requestPath
-     * @return boolean
+     * @param string $requestPath The path from the webserver (the URL which has been opened).
+     * @return boolean|string If the provided $catch_path matches the requestPath it returns true, or if a wild card is used the pattern is returned.
      */
     public function matchRequestPath($requestPath)
     {
         foreach ([$requestPath, urlencode($requestPath), urldecode($requestPath)] as $path) {
             foreach ([$this->catch_path, urlencode($this->catch_path), urldecode($this->catch_path)] as $catch) {
-                if ($this->pathMatcher($path, $catch)) {
-                    return true;
+                if ($response = $this->pathMatcher($path, $catch)) {
+                    return $response;
                 }
             }
         }
@@ -161,6 +176,17 @@ class Redirect extends NgRestModel
         $requestPath = '/'.ltrim($input, '/');
         // see if wildcard string matches
         if (StringHelper::startsWithWildcard($requestPath, $catchPath)) {
+
+            $pattern = str_replace('\*', '(.*)', preg_quote($catchPath, '/'));
+
+            if (preg_match('/'.$pattern.'/i', $requestPath, $result) == 1) {
+                if (isset($result[1]) && !empty($result[1])) {
+                    return $result[1];
+                }
+
+                return true;
+            }
+            
             return true;
         }
         // compare strings
@@ -169,10 +195,17 @@ class Redirect extends NgRestModel
     
     /**
      *
+     * @param string $wildcard An optional wildcard string which can be used as with `*` in the redirect_path
      * @return string
      */
-    public function getRedirectUrl()
+    public function getRedirectUrl($wildcard = null)
     {
-        return Url::to($this->redirect_path);
+        $redirectPath = $this->redirect_path;
+
+        if ($wildcard) {
+            $redirectPath = str_replace('*', $wildcard, $redirectPath);
+        }
+
+        return Url::to($redirectPath);
     }
 }

--- a/src/models/Redirect.php
+++ b/src/models/Redirect.php
@@ -147,7 +147,7 @@ class Redirect extends NgRestModel
      * `foo/*` catch_path would return `bar` when the request path is `foo/bar`.
      *
      * @param string $requestPath The path from the webserver (the URL which has been opened).
-     * @return boolean|string If the provided $catch_path matches the requestPath it returns true, or if a wild card is used the pattern is returned.
+     * @return boolean|string If the provided $catch_path matches the requestPath it returns true, or if a wild card is used the pattern is returned. {@since 3.5.0}
      */
     public function matchRequestPath($requestPath)
     {
@@ -167,7 +167,7 @@ class Redirect extends NgRestModel
      *
      * @param string $input The input request path
      * @param string $catchPath The path to catch
-     * @return boolean
+     * @return boolean|string Returns either true, false or if a wildcard is used, the value is returned {@since 3.5.0}
      * @since 1.0.8
      */
     private function pathMatcher($input, $catchPath)
@@ -195,7 +195,7 @@ class Redirect extends NgRestModel
     
     /**
      *
-     * @param string $wildcard An optional wildcard string which can be used as with `*` in the redirect_path
+     * @param string $wildcard An optional wildcard string which can be used as with `*` in the redirect_path. {@since 3.5.0}
      * @return string
      */
     public function getRedirectUrl($wildcard = null)

--- a/tests/src/models/RedirectTest.php
+++ b/tests/src/models/RedirectTest.php
@@ -44,5 +44,17 @@ class RedirectTest extends ModelTestCase
         $this->assertFalse($rule->matchRequestPath('fo'));
         $rule->catch_path = '/page';
         $this->assertFalse($rule->matchRequestPath('/en/page'));
+
+        // test redirect
+
+        $rule->redirect_path = 'foobar';
+
+        $this->assertSame('foobar', $rule->getRedirectUrl());
+        $this->assertSame('foobar', $rule->getRedirectUrl('slug'));
+
+        $rule->redirect_path = 'foobar/*';
+
+        $this->assertSame('foobar/*', $rule->getRedirectUrl());
+        $this->assertSame('foobar/slug', $rule->getRedirectUrl('slug'));
     }
 }

--- a/tests/src/models/RedirectTest.php
+++ b/tests/src/models/RedirectTest.php
@@ -16,6 +16,12 @@ class RedirectTest extends ModelTestCase
 
         $rule = new Redirect();
 
+        // test new wildcard
+
+        $rule->catch_path = '/storage/*';
+
+        $this->assertSame('mypdf.pdf', $rule->matchRequestPath('/storage/mypdf.pdf'));
+
         // true
         $rule->catch_path = '/foobar';
         $this->assertTrue($rule->matchRequestPath('foobar'));
@@ -28,9 +34,9 @@ class RedirectTest extends ModelTestCase
         $this->assertTrue($rule->matchRequestPath('foo+bar'));
 
         $rule->catch_path = '/foo*';
-        $this->assertTrue($rule->matchRequestPath('foobar'));
+        $this->assertSame('bar', $rule->matchRequestPath('foobar'));
         $this->assertTrue($rule->matchRequestPath('foo'));
-        $this->assertTrue($rule->matchRequestPath('/foobar'));
+        $this->assertSame('bar', $rule->matchRequestPath('/foobar'));
 
         // false
         $rule->catch_path = '/foo*';


### PR DESCRIPTION
Add the option to use the defined wildcard value in redirects for the target. From path `foo/*` to destination `luya.io?path=*`. The given example would redirect `foo/hello-world` to `luya.io?path=hello-word`.

closes #316 