### PR TITLE
fix #348 add default value for user/group permission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ In order to read more about upgrading and BC breaks have a look at the [UPGRADE 
 
 ## 4.0.0
 
+* [#349](https://github.com/luyadev/luya-module-cms/pull/349) Fix default/initial website permissions on first setup for users and groups.
 * [#345](https://github.com/luyadev/luya-module-cms/pull/345) Added Website user and group permission support
 * [#344](https://github.com/luyadev/luya-module-cms/pull/344) Added website collapse to page permission.
 * [#274](https://github.com/luyadev/luya-module-cms/pull/274) Multiple website support.

--- a/src/admin/helpers/MenuHelper.php
+++ b/src/admin/helpers/MenuHelper.php
@@ -310,6 +310,8 @@ class MenuHelper
                 return true;
             }
         }
+        
+        return false;
     }
     
     private static $drafts;

--- a/src/admin/migrations/m210605_172811_cms_website_permissions.php
+++ b/src/admin/migrations/m210605_172811_cms_website_permissions.php
@@ -13,8 +13,8 @@ class m210605_172811_cms_website_permissions extends Migration
      */
     public function safeUp()
     {
-        $this->addColumn(Website::tableName(), 'group_ids', $this->text());
-        $this->addColumn(Website::tableName(), 'user_ids', $this->text());
+        $this->addColumn(Website::tableName(), 'group_ids', $this->text()->defaultValue('[{"value":0}]'));
+        $this->addColumn(Website::tableName(), 'user_ids', $this->text()->defaultValue('[{"value":0}]'));
     }
 
     /**


### PR DESCRIPTION
Fix for luyadev/luya-module-cms/issues/348. I added the default value for user and groups column to set website always so all users/groups. Becasue the migration wasn't released yet, it's easiest way to fix it without a new migration. 