### PR TITLE
Revert "fix #348 add default value for user/group permission"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ In order to read more about upgrading and BC breaks have a look at the [UPGRADE 
 
 ## 4.0.0
 
-* [#349](https://github.com/luyadev/luya-module-cms/pull/349) Fix default/initial website permissions on first setup for users and groups.
 * [#345](https://github.com/luyadev/luya-module-cms/pull/345) Added Website user and group permission support
 * [#344](https://github.com/luyadev/luya-module-cms/pull/344) Added website collapse to page permission.
 * [#274](https://github.com/luyadev/luya-module-cms/pull/274) Multiple website support.

--- a/src/admin/helpers/MenuHelper.php
+++ b/src/admin/helpers/MenuHelper.php
@@ -310,8 +310,6 @@ class MenuHelper
                 return true;
             }
         }
-        
-        return false;
     }
     
     private static $drafts;

--- a/src/admin/migrations/m210605_172811_cms_website_permissions.php
+++ b/src/admin/migrations/m210605_172811_cms_website_permissions.php
@@ -13,8 +13,8 @@ class m210605_172811_cms_website_permissions extends Migration
      */
     public function safeUp()
     {
-        $this->addColumn(Website::tableName(), 'group_ids', $this->text()->defaultValue('[{"value":0}]'));
-        $this->addColumn(Website::tableName(), 'user_ids', $this->text()->defaultValue('[{"value":0}]'));
+        $this->addColumn(Website::tableName(), 'group_ids', $this->text());
+        $this->addColumn(Website::tableName(), 'user_ids', $this->text());
     }
 
     /**


### PR DESCRIPTION
Reverts luyadev/luya-module-cms#349

```
add column group_ids text DEFAULT '[{"value":0}]' to table cms_website ...Exception: SQLSTATE[42000]: Syntax error or access violation: 1101 BLOB, TEXT, GEOMETRY or JSON column 'group_ids' can't have a default value
```