### PR TITLE
Changed misleading icon for page properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ In order to read more about upgrading and BC breaks have a look at the [UPGRADE 
 
 ## 4.1.0 ()
 
++ [#360](https://github.com/luyadev/luya-module-cms/pull/360) Changed misleading icon for page properties in dropdown menu.
 + [#354](https://github.com/luyadev/luya-module-cms/pull/354) Added property `$enableWebsiteHostRedirect` to cms module to enable or disable the `WebsiteBehaviorUrlRule`.
 + [#359](https://github.com/luyadev/luya-module-cms/pull/359) Fix issue with logging cms nav item when deleted.
 

--- a/src/admin/views/page/update.php
+++ b/src/admin/views/page/update.php
@@ -72,7 +72,7 @@ use luya\cms\helpers\Url;
                                 <i class="material-icons">tag</i> <span><?= AdminModule::t('menu_system_item_tags'); ?></span>
                             </a>    
                             <a class="dropdown-item" ng-click="togglePageSettingsOverlay(2)" ng-if="propertiesData.length > 0">
-                                <i class="material-icons">widgets</i> <span><?= Module::t('view_update_properties_title'); ?></span>
+                                <i class="material-icons">menu_open</i> <span><?= Module::t('view_update_properties_title'); ?></span>
                             </a>
                             <a class="dropdown-item" ng-click="togglePageSettingsOverlay(4)">
                                 <i class="material-icons">content_copy</i> <span><?= Module::t('page_update_actions_deepcopy_title'); ?></span>

--- a/src/admin/views/page/update.php
+++ b/src/admin/views/page/update.php
@@ -72,7 +72,7 @@ use luya\cms\helpers\Url;
                                 <i class="material-icons">tag</i> <span><?= AdminModule::t('menu_system_item_tags'); ?></span>
                             </a>    
                             <a class="dropdown-item" ng-click="togglePageSettingsOverlay(2)" ng-if="propertiesData.length > 0">
-                                <i class="material-icons">list</i> <span><?= Module::t('view_update_properties_title'); ?></span>
+                                <i class="material-icons">widgets</i> <span><?= Module::t('view_update_properties_title'); ?></span>
                             </a>
                             <a class="dropdown-item" ng-click="togglePageSettingsOverlay(4)">
                                 <i class="material-icons">content_copy</i> <span><?= Module::t('page_update_actions_deepcopy_title'); ?></span>

--- a/src/admin/views/page/update.php
+++ b/src/admin/views/page/update.php
@@ -72,7 +72,7 @@ use luya\cms\helpers\Url;
                                 <i class="material-icons">tag</i> <span><?= AdminModule::t('menu_system_item_tags'); ?></span>
                             </a>    
                             <a class="dropdown-item" ng-click="togglePageSettingsOverlay(2)" ng-if="propertiesData.length > 0">
-                                <i class="material-icons">settings</i> <span><?= Module::t('view_update_properties_title'); ?></span>
+                                <i class="material-icons">list</i> <span><?= Module::t('view_update_properties_title'); ?></span>
                             </a>
                             <a class="dropdown-item" ng-click="togglePageSettingsOverlay(4)">
                                 <i class="material-icons">content_copy</i> <span><?= Module::t('page_update_actions_deepcopy_title'); ?></span>


### PR DESCRIPTION
### What are you changing/introducing
Icon for page properties inside the dropdown menu.

### What is the reason for changing/introducing
Settings icon should not be used for page properties,
more than ever inside the dropdown menu, because the settings icon is used for the dropdown menu itself.