### PR TITLE
Fixed event function name for website delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](http://semver.org/).
 In order to read more about upgrading and BC breaks have a look at the [UPGRADE Document](UPGRADE.md).
 
+## 4.2.1
+
++ [#375](https://github.com/luyadev/luya-module-cms/pull/375) Fixed Website delete event
+
 ## 4.2.0 (9. December 2021)
 
 + [#322](https://github.com/luyadev/luya-module-cms/issues/322) Added `save` and `save&close` buttons to blocks.

--- a/src/models/Website.php
+++ b/src/models/Website.php
@@ -211,7 +211,7 @@ class Website extends NgRestModel
         }
     }
     
-    public function afterDelete()
+    public function eventAfterDelete()
     {
         $this->updateAttributes(['is_active' => false]);
     }


### PR DESCRIPTION
### What are you changing/introducing

Changed function name from `afterDelete()` to `eventAfterDelete()`.

### What is the reason for changing/introducing

`eventAfterDelete()` is registered for `EVENT_AFTER_DELETE` (line 45),
but there is "only" a function overriding of `BaseActiveRecord`'s `afterDelete()`.

### QA

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | -
