### PR TITLE
directory separators and line endings fixes

### DIFF
--- a/tests/CmsConsoleTestCase.php
+++ b/tests/CmsConsoleTestCase.php
@@ -12,7 +12,7 @@ class CmsConsoleTestCase extends ConsoleApplicationTestCase
             'id' => 'basetestcase',
             'basePath' => dirname(__DIR__),
             'aliases' => [
-                '@cmstests' => dirname(__DIR__),
+                '@cmstests' => '.',
             ],
             'components' => [
                 'db' => [

--- a/tests/src/base/BaseBlockInjectorTest.php
+++ b/tests/src/base/BaseBlockInjectorTest.php
@@ -66,3 +66,12 @@ class LinkInjectorTest extends CmsFrontendTestCase
         $this->assertSame('zaa-text', $cfgs[0]['type']);
     }
 }
+
+
+class BaseBlockInjectorTest extends CmsFrontendTestCase
+{
+    public function testDummy()
+    {
+
+    }
+}

--- a/tests/src/base/PhpBlockTest.php
+++ b/tests/src/base/PhpBlockTest.php
@@ -60,6 +60,6 @@ class PhpBlockTest extends CmsFrontendTestCase
         $block = new PhpTestBlock();
         $block->module = null;
 
-        $this->assertStringContainsString('tests/data/blocks/views', $block->getViewPath());
+        $this->assertStringContainsString('tests'.DIRECTORY_SEPARATOR.'data'.DIRECTORY_SEPARATOR.'blocks'.DIRECTORY_SEPARATOR.'views', $block->getViewPath());
     }
 }

--- a/tests/src/frontend/commands/BlockControllerTest.php
+++ b/tests/src/frontend/commands/BlockControllerTest.php
@@ -324,6 +324,6 @@ EOT;
 ?>
 
 EOT;
-        $this->assertSame($view, $ctrl->generateViewFile('MySuperBlock'));
+        $this->assertSame(str_replace(["\r\n", "\r"], "\n", $view), str_replace(["\r\n", "\r"], "\n", $ctrl->generateViewFile('MySuperBlock')));
     }
 }

--- a/tests/src/models/NavItemPageTest.php
+++ b/tests/src/models/NavItemPageTest.php
@@ -103,7 +103,7 @@ class NavItemPageTest extends WebModelTestCase
         try {
             $model->getContent();
         } catch (\Exception $e) {
-            $this->assertStringContainsString('luya-module-cms/views/cmslayouts/relative.php', $e->getMessage());
+            $this->assertStringContainsString('luya-module-cms/views/cmslayouts'.DIRECTORY_SEPARATOR.'relative.php', $e->getMessage());
         }
     }
 }

--- a/tests/src/widgets/LangSwitcherTest.php
+++ b/tests/src/widgets/LangSwitcherTest.php
@@ -9,10 +9,12 @@ class LangSwitcherTest extends CmsFrontendTestCase
 {
     public function testWidgetOutput()
     {
-        $this->assertSame('<ul class="list-element">
+        $out =  LangSwitcher::widget();
+
+        $this->assertSame(str_replace(["\r\n", "\r"], "\n", '<ul class="list-element">
 <li class="lang-element-item lang-element-item--active"><a class="lang-link-item lang-link-item--active" href="http://localhost/luya/envs/dev/public_html/">English</a></li>
 <li class="lang-element-item"><a class="lang-link-item" href="http://localhost/luya/envs/dev/public_html/de">Deutsch</a></li>
-</ul>', LangSwitcher::widget());
+</ul>'), str_replace(["\r\n", "\r"], "\n", $out));
     }
 
     public function testCallable()
@@ -21,10 +23,10 @@ class LangSwitcherTest extends CmsFrontendTestCase
             return strtoupper($lang['short_code']);
         }]);
 
-        $this->assertSame('<ul class="list-element">
+        $this->assertSame(str_replace(["\r\n", "\r"], "\n",'<ul class="list-element">
 <li class="lang-element-item lang-element-item--active"><a class="lang-link-item lang-link-item--active" href="http://localhost/luya/envs/dev/public_html/">EN</a></li>
 <li class="lang-element-item"><a class="lang-link-item" href="http://localhost/luya/envs/dev/public_html/de">DE</a></li>
-</ul>', $out);
+</ul>'), str_replace(["\r\n", "\r"], "\n", $out));
     }
 
     public function testSortCallable()
@@ -36,17 +38,17 @@ class LangSwitcherTest extends CmsFrontendTestCase
         }]);
 
 
-        $this->assertSame('<ul class="list-element">
+        $this->assertSame(str_replace(["\r\n", "\r"], "\n",'<ul class="list-element">
 <li class="lang-element-item"><a class="lang-link-item" href="http://localhost/luya/envs/dev/public_html/de">Deutsch</a></li>
 <li class="lang-element-item lang-element-item--active"><a class="lang-link-item lang-link-item--active" href="http://localhost/luya/envs/dev/public_html/">English</a></li>
-</ul>', $out);
+</ul>'), str_replace(["\r\n", "\r"], "\n", $out));
     }
 
     public function testOutputWithoutUl()
     {
         $out = LangSwitcher::widget(['noListTag' => true]);
 
-        $this->assertSame('<li class="lang-element-item lang-element-item--active"><a class="lang-link-item lang-link-item--active" href="http://localhost/luya/envs/dev/public_html/">English</a></li>
-<li class="lang-element-item"><a class="lang-link-item" href="http://localhost/luya/envs/dev/public_html/de">Deutsch</a></li>', $out);
+        $this->assertSame(str_replace(["\r\n", "\r"], "\n",'<li class="lang-element-item lang-element-item--active"><a class="lang-link-item lang-link-item--active" href="http://localhost/luya/envs/dev/public_html/">English</a></li>
+<li class="lang-element-item"><a class="lang-link-item" href="http://localhost/luya/envs/dev/public_html/de">Deutsch</a></li>'), str_replace(["\r\n", "\r"], "\n", $out));
     }
 }


### PR DESCRIPTION
### What are you changing/introducing

Fixed a few tests to make them run on Windows systems.

* Added a BaseBlockInjectorTest dymmy class to match the filename.
* Added a DIRECTORY_SEPARATOR instead of /.
* Added a replace of "\r\n" and "\r" to "\n". This is to ignore autocrlf conversion on git pull/push on different operating systems.
* Changed '@ cmstests' alias to '.'. **Please check it** 


### QA
| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | 
