### PR TITLE
Fixed missing env options in admin context

### DIFF
--- a/src/base/NavItemType.php
+++ b/src/base/NavItemType.php
@@ -9,9 +9,9 @@ use yii\db\ActiveRecord;
 /**
  * Abstract class for all Item Types.
  *
-* @property NavItem $navItem
  * @property Controller $controller The controller object.
  * @property array $options Optional settings for the nav item type.
+ * @property NavItem $navItem
  *
  * @author Basil Suter <basil@nadar.io>
  * @since 1.0.0
@@ -25,8 +25,6 @@ abstract class NavItemType extends ActiveRecord implements NavItemTypeInterface
      */
     abstract public function getContent();
 
-    private $_navItem;
-    
     /**
      * Get the corresponding nav item type for this type object
      *
@@ -34,11 +32,7 @@ abstract class NavItemType extends ActiveRecord implements NavItemTypeInterface
      */
     public function getNavItem()
     {
-        if ($this->_navItem === null) {
-            $this->_navItem = $this->hasOne(NavItem::class, ['nav_item_type_id' => 'id'])->where(['nav_item_type' => static::getNummericType()]);
-        }
-
-        return $this->_navItem;
+        return $this->hasOne(NavItem::class, ['nav_item_type_id' => 'id'])->where(['nav_item_type' => static::getNummericType()]);
     }
 
     /**

--- a/src/base/NavItemType.php
+++ b/src/base/NavItemType.php
@@ -9,9 +9,9 @@ use yii\db\ActiveRecord;
 /**
  * Abstract class for all Item Types.
  *
+* @property NavItem $navItem
  * @property Controller $controller The controller object.
  * @property array $options Optional settings for the nav item type.
- * @property NavItem $navItem
  *
  * @author Basil Suter <basil@nadar.io>
  * @since 1.0.0
@@ -25,6 +25,8 @@ abstract class NavItemType extends ActiveRecord implements NavItemTypeInterface
      */
     abstract public function getContent();
 
+    private $_navItem;
+    
     /**
      * Get the corresponding nav item type for this type object
      *
@@ -32,7 +34,11 @@ abstract class NavItemType extends ActiveRecord implements NavItemTypeInterface
      */
     public function getNavItem()
     {
-        return $this->hasOne(NavItem::class, ['nav_item_type_id' => 'id'])->where(['nav_item_type' => static::getNummericType()]);
+        if ($this->_navItem === null) {
+            $this->_navItem = $this->hasOne(NavItem::class, ['nav_item_type_id' => 'id'])->where(['nav_item_type' => static::getNummericType()]);
+        }
+
+        return $this->_navItem;
     }
 
     /**

--- a/src/models/NavItemPage.php
+++ b/src/models/NavItemPage.php
@@ -447,10 +447,8 @@ class NavItemPage extends NavItemType implements NavItemTypeInterface, ViewConte
 
     /**
      * Get the arrayable values from a specific block.
-     *
-     * @return array|false
      */
-    public static function getBlockItem(NavItemPageBlockItem $blockItem, NavItemPage $navItemPage)
+    public static function getBlockItem(NavItemPageBlockItem $blockItem, NavItemPage $navItemPage): array|false
     {
         // if the block relation could not be found, return false.
         if (!$blockItem->block) {

--- a/src/models/NavItemPage.php
+++ b/src/models/NavItemPage.php
@@ -446,9 +446,10 @@ class NavItemPage extends NavItemType implements NavItemTypeInterface, ViewConte
     }
 
     /**
-     * Get the arrayable values from a specific block id.
+     * Get the arrayable values from a specific block.
      *
-     * @param integer $blockId
+     * @param \luya\cms\models\NavItemPageBlockItem $blockItem
+     * @param \luya\cms\models\NavItemPage $navItemPage
      * @return array
      */
     public static function getBlockItem(NavItemPageBlockItem $blockItem, NavItemPage $navItemPage)
@@ -458,7 +459,7 @@ class NavItemPage extends NavItemType implements NavItemTypeInterface, ViewConte
             return false;
         }
 
-        $blockObject = $blockItem->block->getObject($blockItem->id, 'admin', $navItemPage);
+        $blockObject = $blockItem->block->getObject($blockItem->id, 'admin', $navItemPage->getNavItem());
         if ($blockObject === false) {
             return false;
         }

--- a/src/models/NavItemPage.php
+++ b/src/models/NavItemPage.php
@@ -448,13 +448,11 @@ class NavItemPage extends NavItemType implements NavItemTypeInterface, ViewConte
     /**
      * Get the arrayable values from a specific block.
      *
-     * @param \luya\cms\models\NavItemPageBlockItem $blockItem
-     * @param \luya\cms\models\NavItemPage $navItemPage
-     * @return array
+     * @return array|false
      */
     public static function getBlockItem(NavItemPageBlockItem $blockItem, NavItemPage $navItemPage)
     {
-        // if the block relation could be found, return false.
+        // if the block relation could not be found, return false.
         if (!$blockItem->block) {
             return false;
         }


### PR DESCRIPTION
### What are you changing/introducing

- Fixed the passed "page object" for admin context, so env option `'pageObject'` is available
- Added env options `'index'`, `'itemsCount'`, `'isFirst'`, `'isLast'`, `'isPrevEqual'`, `'isNextEqual'` and `'equalIndex'` for admin context in the block iteration in `getPlaceholder()` analog to `renderPlaceholderRecursive()`
- Multiple return type for `NavItemPage::getBlockItem()`

### What is the reason for changing/introducing

- See issue #401

### QA

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | Please let the PR open!
