### PR TITLE
Cmsadmin padding fix for blockholder collapsed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ In order to read more about upgrading and BC breaks have a look at the [UPGRADE 
 
 ## 5.0.1
 
++ [#404](https://github.com/luyadev/luya-module-cms/pull/404) Cmsadmin padding fix for blockholder collapsed
 + [#400](https://github.com/luyadev/luya-module-cms/pull/400) Improved translations (bg, cn, es, fr, hu, id, kr, nl, pl) and updated link to new guide.
 
 ## 5.0.0 (30. November 2023)

--- a/src/admin/resources/scss/components/_cmsadmin.scss
+++ b/src/admin/resources/scss/components/_cmsadmin.scss
@@ -36,7 +36,7 @@
 
 .cmsadmin-blockholder-collapsed {
     @media (min-width: $mobile-nav-breakpoint) {
-        margin: 0 $blockholder-width-small 0 0;
+        margin: -10px $blockholder-width-small 0 0;
     }
 }
 


### PR DESCRIPTION
### What are you changing/introducing

Added negative top margin for cmsadmin in blockholder collapsed state analog to blockholder expanded state.

### What is the reason for changing/introducing

https://github.com/luyadev/luya-module-cms/commit/b5f9b553006c2ab8f2d7a8398268b47358c400a9 added a negative top margin `-10px` for `.cmsadmin` (to fix the top padding #239), but which is overridden by `.cmsadmin-blockholder-collapsed` in blockholder collapsed state. This results in a jumping cmsadmin, see:

![cmsadmin_margin_offset](https://github.com/luyadev/luya-module-cms/assets/6715827/ccacdbe2-0f15-491b-9756-242a3bc1c015)


### QA

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    |no
| Tests pass?   | yes
| Fixed issues  | &ndash;
