### PR TITLE
Fixed website and theme status ActiveButtons (PHP 8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ In order to read more about upgrading and BC breaks have a look at the [UPGRADE 
 
 ## 5.0.1
 
++ [#406](https://github.com/luyadev/luya-module-cms/pull/406) Fixed website and theme status ActiveButtons (PHP 8)
 + [#400](https://github.com/luyadev/luya-module-cms/pull/400) Improved translations (bg, cn, es, fr, hu, id, kr, nl, pl) and updated link to new guide.
 
 ## 5.0.0 (30. November 2023)

--- a/src/models/Theme.php
+++ b/src/models/Theme.php
@@ -108,6 +108,8 @@ class Theme extends NgRestModel
             [
                 'class' => 'luya\admin\buttons\ToggleStatusActiveButton',
                 'attribute' => 'is_default',
+                'enableValue' => 1,
+                'disableValue' => 0,
                 'uniqueStatus' => true,
                 'modelNameAttribute' => 'name',
                 'label' => 'Toggle default',

--- a/src/models/Website.php
+++ b/src/models/Website.php
@@ -172,6 +172,8 @@ class Website extends NgRestModel
             [
                 'class' => 'luya\admin\buttons\ToggleStatusActiveButton',
                 'attribute' => 'is_default',
+                'enableValue' => 1,
+                'disableValue' => 0,
                 'uniqueStatus' => true,
                 'modelNameAttribute' => 'name',
                 'label' => 'Set default',


### PR DESCRIPTION
### What are you changing/introducing

- Set explicitly `enableValue=1` and `disableValue=0` for `ToggleStatusActiveButton` in `Website` and `Theme` model.

### What is the reason for changing/introducing

Rector replaced the `switch` statement in `luya-module-admin/src/buttons/ToggleStatusActiveButton::toggleValue()` with new PHP 8 `match` statement (see https://github.com/luyadev/luya-module-admin/commit/5e0574ad26b76fa19b87f390bada6aaf7339605c).

Because of
> Unlike switch, the comparison is an identity check (===) rather than a weak equality check (==).
https://www.php.net/manual/en/control-structures.match.php

toggling to other values than `true` or `false` leads into an `InvalidArgumentException`.

### QA

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | Closes #405
