### PR TITLE
Unit tests for block env options

### DIFF
--- a/src/models/NavItemPage.php
+++ b/src/models/NavItemPage.php
@@ -298,13 +298,7 @@ class NavItemPage extends NavItemType implements NavItemTypeInterface, ViewConte
                     $prevIsEqual = array_key_exists($prev, $placeholders) && $placeholder['block_id'] == $placeholders[$prev]['block_id'];
                     $blockObject->setEnvOption('isPrevEqual', $prevIsEqual);
                     $blockObject->setEnvOption('isNextEqual', array_key_exists($next, $placeholders) && $placeholder['block_id'] == $placeholders[$next]['block_id']);
-
-                    if (!$prevIsEqual) {
-                        $equalIndex = 1;
-                    } else {
-                        $equalIndex++;
-                    }
-                    $blockObject->setEnvOption('equalIndex', $equalIndex);
+                    $blockObject->setEnvOption('equalIndex', (!$prevIsEqual) ? $equalIndex = 1 : ++$equalIndex);
 
                     // render sub placeholders and set into object
                     $insertedHolders = [];
@@ -449,7 +443,7 @@ class NavItemPage extends NavItemType implements NavItemTypeInterface, ViewConte
                 'isLast' => ($i == $blocksCount),
                 'isPrevEqual' => $prevIsEqual,
                 'isNextEqual' => array_key_exists($next, $nav_item_page_block_item_data) && $blockItem['block_id'] == $nav_item_page_block_item_data[$next]['block_id'],
-                'equalIndex' => (!$prevIsEqual) ? ($equalIndex = 1) : ($equalIndex++)
+                'equalIndex' => (!$prevIsEqual) ? $equalIndex = 1 : ++$equalIndex
             ];
 
             $item = self::getBlockItem($blockItem, $navItemPage, $envOptions);

--- a/tests/data/blocks/TestBlock.php
+++ b/tests/data/blocks/TestBlock.php
@@ -33,6 +33,11 @@ class TestBlock extends PhpBlock
 
     public function admin()
     {
-        return [$this->getVarValue('var1'), $this->getVarValue('var2')];
+        return [
+            $this->getVarValue('var1'),
+            $this->getVarValue('var2'),
+            $this->getCfgValue('cfg1'),
+            $this->getEnvOptions(),
+        ];
     }
 }

--- a/tests/data/blocks/import/TestBlock.php
+++ b/tests/data/blocks/import/TestBlock.php
@@ -33,6 +33,11 @@ class TestBlock extends PhpBlock
 
     public function admin()
     {
-        return [$this->getVarValue('var1'), $this->getVarValue('var2')];
+        return [
+            $this->getVarValue('var1'),
+            $this->getVarValue('var2'),
+            $this->getCfgValue('cfg1'),
+            $this->getEnvOptions(),
+        ];
     }
 }

--- a/tests/src/base/BlockPlaceholderIterationTest.php
+++ b/tests/src/base/BlockPlaceholderIterationTest.php
@@ -35,7 +35,7 @@ class BlockPlaceholderIterationTest extends CmsFrontendTestCase
                     'group_id' => 1,
                     'class' => TestingLayoutBlock::class,
                     'is_disabled' => 0,
-                ]
+                ],
             ]
         ]);
 
@@ -48,7 +48,7 @@ class BlockPlaceholderIterationTest extends CmsFrontendTestCase
                     'nav_item_id' => 1,
                     'timestamp_create' => time(),
                     'version_alias' => 'barfoo',
-                ]
+                ],
             ]
         ]);
 
@@ -93,11 +93,186 @@ class BlockPlaceholderIterationTest extends CmsFrontendTestCase
 
         $block1 = $blockFixture->getModel('block1');
         $block2 = $blockFixture->getModel('block2');
+        $block3 = $blockFixture->getModel('block3');
         $page = $pageFixture->getModel('page1');
         $blockItem1 = $blockItemFixture->getModel('item1');
         $blockItem2 = $blockItemFixture->getModel('item2');
 
         $this->assertSame('<div class="render-frontend"><box><div class="block">foo</div></box><box><div class="block">bar</div></box></div>', $page->renderPlaceholder('content'));
+    }
+
+    public function testEnvOptionsPlaceholderIteration()
+    {
+        $this->app->setComponents([
+            'db' => [
+                'class' => 'yii\db\Connection',
+                'dsn' => 'sqlite::memory:',
+            ]
+        ]);
+
+        $blockFixture = new NgRestModelFixture([
+            'modelClass' => Block::class,
+            'fixtureData' => [
+                'block1' => [
+                    'id' => 1,
+                    'group_id' => 1,
+                    'class' => TestingEnvOptionsBlock::class,
+                    'is_disabled' => 0,
+                ],
+            ]
+        ]);
+
+        $pageFixture = new ActiveRecordFixture([
+            'modelClass' => NavItemPage::class,
+            'fixtureData' => [
+                'page1' => [
+                    'id' => 1,
+                    'layout_id' => 1,
+                    'nav_item_id' => 1,
+                    'timestamp_create' => time(),
+                    'version_alias' => 'barfoo',
+                ],
+            ]
+        ]);
+
+        $blockItemFixture = new NgRestModelFixture([
+            'modelClass' => NavItemPageBlockItem::class,
+            'fixtureData' => [
+                'item1' => [
+                    'id' => 1,
+                    'block_id' => 1,
+                    'placeholder_var' => 'content',
+                    'nav_item_page_id' => 1,
+                    'prev_id' => 0,
+                    'json_config_values' => '{}',
+                    'json_config_cfg_values' => '{}',
+                    'variation' => '',
+                    'is_hidden' => 0,
+                ],
+                'item2' => [
+                    'id' => 2,
+                    'block_id' => 1,
+                    'placeholder_var' => 'content',
+                    'nav_item_page_id' => 1,
+                    'prev_id' => 0,
+                    'json_config_values' => '{}',
+                    'json_config_cfg_values' => '{}',
+                    'variation' => '',
+                    'is_hidden' => 0,
+                ],
+                'item3' => [
+                    'id' => 3,
+                    'block_id' => 1,
+                    'placeholder_var' => 'content',
+                    'nav_item_page_id' => 1,
+                    'prev_id' => 0,
+                    'json_config_values' => '{}',
+                    'json_config_cfg_values' => '{}',
+                    'variation' => '',
+                    'is_hidden' => 0,
+                ],
+            ]
+        ]);
+
+        $block1 = $blockFixture->getModel('block1');
+        $page = $pageFixture->getModel('page1');
+        $blockItem1 = $blockItemFixture->getModel('item1');
+        $blockItem2 = $blockItemFixture->getModel('item2');
+        $blockItem3 = $blockItemFixture->getModel('item3');
+
+        // admin:
+
+        $adminBlockItems = NavItemPage::getPlaceholder('content', 0, $page);
+
+        $envOptions1 = $adminBlockItems[0]['twig_admin'];
+        $envOptions2 = $adminBlockItems[1]['twig_admin'];
+        $envOptions3 = $adminBlockItems[2]['twig_admin'];
+
+        $this->assertSame(1, $envOptions1['id']);
+        $this->assertSame(1, $envOptions1['blockId']);
+        $this->assertSame('admin', $envOptions1['context']);
+        //@TODO assertInstanceOf() for pageObject
+        $this->assertNotEquals(false, $envOptions1['pageObject']);
+        $this->assertSame(1, $envOptions1['index']);
+        $this->assertSame(3, $envOptions1['itemsCount']);
+        $this->assertTrue($envOptions1['isFirst']);
+        $this->assertFalse($envOptions1['isLast']);
+        $this->assertFalse($envOptions1['isPrevEqual']);
+        $this->assertTrue($envOptions1['isNextEqual']);
+        $this->assertSame(1, $envOptions1['equalIndex']);
+
+        $this->assertSame(2, $envOptions2['id']);
+        $this->assertSame(1, $envOptions2['blockId']);
+        $this->assertSame('admin', $envOptions2['context']);
+        //@TODO assertInstanceOf() for pageObject
+        $this->assertNotEquals(false, $envOptions2['pageObject']);
+        $this->assertSame(2, $envOptions2['index']);
+        $this->assertSame(3, $envOptions2['itemsCount']);
+        $this->assertFalse($envOptions2['isFirst']);
+        $this->assertFalse($envOptions2['isLast']);
+        $this->assertTrue($envOptions2['isPrevEqual']);
+        $this->assertTrue($envOptions2['isNextEqual']);
+        $this->assertSame(2, $envOptions2['equalIndex']);
+
+        $this->assertSame(3, $envOptions3['id']);
+        $this->assertSame(1, $envOptions3['blockId']);
+        $this->assertSame('admin', $envOptions3['context']);
+        //@TODO assertInstanceOf() for pageObject
+        $this->assertNotEquals(false, $envOptions2['pageObject']);
+        $this->assertSame(3, $envOptions3['index']);
+        $this->assertSame(3, $envOptions3['itemsCount']);
+        $this->assertFalse($envOptions3['isFirst']);
+        $this->assertTrue($envOptions3['isLast']);
+        $this->assertTrue($envOptions3['isPrevEqual']);
+        $this->assertFalse($envOptions3['isNextEqual']);
+        $this->assertSame(3, $envOptions3['equalIndex']);
+
+        // frontend:
+
+        $frontendEnvOptions = json_decode($page->renderPlaceholder('content'), true);
+
+        $envOptions1 = $frontendEnvOptions[0];
+        $envOptions2 = $frontendEnvOptions[1];
+        $envOptions3 = $frontendEnvOptions[2];
+
+        $this->assertSame(1, $envOptions1['id']);
+        $this->assertSame(1, $envOptions1['blockId']);
+        $this->assertSame('frontend', $envOptions1['context']);
+        //@TODO assertInstanceOf() for pageObject
+        $this->assertNotEquals(false, $envOptions1['pageObject']);
+        $this->assertSame(1, $envOptions1['index']);
+        $this->assertSame(3, $envOptions1['itemsCount']);
+        $this->assertTrue($envOptions1['isFirst']);
+        $this->assertFalse($envOptions1['isLast']);
+        $this->assertFalse($envOptions1['isPrevEqual']);
+        $this->assertTrue($envOptions1['isNextEqual']);
+        $this->assertSame(1, $envOptions1['equalIndex']);
+
+        $this->assertSame(2, $envOptions2['id']);
+        $this->assertSame(1, $envOptions2['blockId']);
+        $this->assertSame('frontend', $envOptions2['context']);
+        //@TODO assertInstanceOf() for pageObject
+        $this->assertNotEquals(false, $envOptions2['pageObject']);
+        $this->assertSame(2, $envOptions2['index']);
+        $this->assertSame(3, $envOptions2['itemsCount']);
+        $this->assertFalse($envOptions2['isFirst']);
+        $this->assertFalse($envOptions2['isLast']);
+        $this->assertTrue($envOptions2['isPrevEqual']);
+        $this->assertTrue($envOptions2['isNextEqual']);
+        $this->assertSame(2, $envOptions2['equalIndex']);
+
+        $this->assertSame(3, $envOptions3['id']);
+        $this->assertSame(1, $envOptions3['blockId']);
+        $this->assertSame('frontend', $envOptions3['context']);
+        //@TODO assertInstanceOf() for pageObject
+        $this->assertNotEquals(false, $envOptions3['pageObject']);
+        $this->assertSame(3, $envOptions3['index']);
+        $this->assertSame(3, $envOptions3['itemsCount']);
+        $this->assertFalse($envOptions3['isFirst']);
+        $this->assertTrue($envOptions3['isLast']);
+        $this->assertTrue($envOptions3['isPrevEqual']);
+        $this->assertFalse($envOptions3['isNextEqual']);
+        $this->assertSame(3, $envOptions3['equalIndex']);
     }
 }
 
@@ -107,6 +282,7 @@ class TestingTextBlock extends InternalBaseBlock
     {
         return 'Content';
     }
+
     public function config()
     {
         return [
@@ -115,10 +291,12 @@ class TestingTextBlock extends InternalBaseBlock
             ]
         ];
     }
+
     public function renderFrontend()
     {
         return '<div class="block">'.$this->getVarValue('var1').'</div>';
     }
+
     public function renderAdmin()
     {
         return '<div>{{ vars.content | raw }}</div>';
@@ -152,5 +330,28 @@ class TestingLayoutBlock extends InternalBaseBlock
     public function placeholderRenderIteration(\luya\cms\base\BlockInterface $block)
     {
         return '<box>'.$block->renderFrontend().'</box>';
+    }
+}
+
+class TestingEnvOptionsBlock extends InternalBaseBlock
+{
+    public function name()
+    {
+        return 'EnvOptions';
+    }
+
+    public function config()
+    {
+        return [];
+    }
+
+    public function renderFrontend()
+    {
+        return (($this->getEnvOption('isFirst')) ? '[' : '') . json_encode($this->getEnvOptions(), JSON_NUMERIC_CHECK) . (($this->getEnvOption('isLast')) ? ']' : ',');
+    }
+
+    public function renderAdmin()
+    {
+        return $this->getEnvOptions();
     }
 }

--- a/tests/src/base/BlockTest.php
+++ b/tests/src/base/BlockTest.php
@@ -5,6 +5,7 @@ namespace tests\web\cmsadmin\base;
 use cmstests\CmsFrontendTestCase;
 use cmstests\data\blocks\TestBlock;
 use luya\cms\base\PhpBlock;
+use yii\db\ActiveRecord;
 
 class GetterSetter extends PhpBlock
 {
@@ -39,9 +40,8 @@ class BlockTest extends CmsFrontendTestCase
     {
         $block = new TestBlock();
 
-        $this->assertEquals(false, $block->isAdminContext());
-        $this->assertEquals(false, $block->isFrontendContext());
-
+        $this->assertFalse($block->isAdminContext());
+        $this->assertFalse($block->isFrontendContext());
 
         foreach ($block->getConfigVarsExport() as $var) {
             $this->assertArrayHasKey('id', $var);
@@ -68,14 +68,47 @@ class BlockTest extends CmsFrontendTestCase
     {
         $block = new TestBlock();
 
-        $block->setEnvOption('blockId', 1);
-        $block->setEnvOption('context', 'admin');
-
         $block->setVarValues(['var1' => 'content var 1', 'var2' => 'content var 2']);
         $block->setCfgValues(['cfg1' => 'content cfg 1']);
 
         $this->assertEquals('content var 1', $block->admin()[0]);
         $this->assertEquals('content var 2', $block->admin()[1]);
+        $this->assertEquals('content cfg 1', $block->admin()[2]);
+    }
+
+    public function testBlockEnvOptions()
+    {
+        $block = new TestBlock();
+        $pageObject = new ActiveRecord(); // @TODO specify class
+
+        $block->setEnvOption('id', 1);
+        $block->setEnvOption('blockId', 1);
+        $block->setEnvOption('context', 'admin');
+        $block->setEnvOption('pageObject', $pageObject);
+        $block->setEnvOption('index', 1);
+        $block->setEnvOption('itemsCount', 1);
+        $block->setEnvOption('isFirst', true);
+        $block->setEnvOption('isLast', true);
+        $block->setEnvOption('isPrevEqual', false);
+        $block->setEnvOption('isNextEqual', false);
+        $block->setEnvOption('equalIndex', 1);
+
+        $this->assertTrue($block->isAdminContext());
+        $this->assertFalse($block->isFrontendContext());
+
+        $envOptions = $block->admin()[3];
+        $this->assertSame(1, $envOptions['id']);
+        $this->assertSame(1, $envOptions['blockId']);
+        $this->assertSame('admin', $envOptions['context']);
+        // @TODO assertInstanceOf() for pageObject
+        $this->assertNotEquals(false, $envOptions['pageObject']);
+        $this->assertSame(1, $envOptions['index']);
+        $this->assertSame(1, $envOptions['itemsCount']);
+        $this->assertTrue($envOptions['isFirst']);
+        $this->assertTrue($envOptions['isLast']);
+        $this->assertFalse($envOptions['isPrevEqual']);
+        $this->assertFalse($envOptions['isNextEqual']);
+        $this->assertSame(1, $envOptions['equalIndex']);
     }
 
     public function testGetterSetter()


### PR DESCRIPTION
### What are you changing/introducing

- Added new unit tests for block env options (except `'pageObject'`)

**Block Test**
- Added new test `BlockTest::testBlockEnvOptions()`
  - Moved setting env options from `BlockTest::testBlockValues()` to this new test
- Enhanced  therefore `TestBlock::admin()`
  - Accessing and returning env options and unused config value
- Improved `BlockTest::testBlockValues()`
   - Checking unused config value

**Block Placeholder Iteration Test**
- Added new test `BlockPlaceholderIterationTest::testEnvOptionsPlaceholderIteration()`
  - 3 equal blocks on 1 page via fixtures
  - Checking env options in admin context via `NavItemPage::getPlaceholder()`
  - Checking env options in frontend context via `NavItemPage::renderPlaceholder()`
- Added therefore new testing block `TestingEnvOptionsBlock`
  - Accessing env options in admin context inside `renderAdmin()`
  - Accessing env options in frontend context inside `renderFrontend()` (JSON decoding/encoding is needed because of internal processing & concat)
- Completed access on all block models in `BlockPlaceholderIterationTest::testRenderPlaceholderIteration()` for sake of completeness

**Bugfix**
- Fixed recently introduced `'equalIndex'` iteration in admin context (pre-increment instead of post-increment)
- Reduced lines of code in frontend context


### What is the reason for changing/introducing

see issue #401 and PR https://github.com/luyadev/luya-module-cms/pull/403

### QA

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | &ndash;