### PR TITLE
Fixed block group extra attribute sorting issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file. This project adheres to [Semantic Versioning](https://semver.org/).
 In order to read more about upgrading and BC breaks have a look at the [UPGRADE Document](UPGRADE.md).
 
+## 5.1.1
+
++ [#410](https://github.com/luyadev/luya-module-cms/pull/410) Fixed block group extra attribute sorting issue.
+
 ## 5.1.0 (7. February 2024)
 
 > This release contains a very small change when using the block `getEnvOption('pageObject')`. Check the [UPGRADE document](UPGRADE.md) to read more about.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ In order to read more about upgrading and BC breaks have a look at the [UPGRADE 
 
 ## 5.1.1
 
-+ [#410](https://github.com/luyadev/luya-module-cms/pull/410) Fixed block group extra attribute sorting issue.
++ [#410](https://github.com/luyadev/luya-module-cms/pull/410) Disabled sorting functionality for the "group" extra field in the block CRUD interface due to an exception being thrown. This issue occurred because the field is declared as an `extraAttribute`.
 
 ## 5.1.0 (7. February 2024)
 

--- a/src/models/BlockGroup.php
+++ b/src/models/BlockGroup.php
@@ -88,7 +88,7 @@ class BlockGroup extends NgRestModel
     public function ngRestExtraAttributeTypes()
     {
         return [
-            'groupLabel' => 'text',
+            'groupLabel' => ['text', 'sortField' => false],
         ];
     }
 


### PR DESCRIPTION
### What are you changing/introducing

- Make block groups' extra attribute `groupLabel` non-sortable


### What is the reason for changing/introducing

- Sorting by *Group* (`groupLabel`) in *Groups Management* table raises a SQL error:
```
SQLSTATE[42S22]: Column not found: 1054 Unknown column 'groupLabel' in 'order clause'
The SQL being executed was: SELECT * FROM `cms_block_group` WHERE `cms_block_group`.`is_deleted`=FALSE ORDER BY `groupLabel` LIMIT 25
```
![Bildschirmfoto 2024-02-20 um 23 31 25](https://github.com/luyadev/luya-module-cms/assets/6715827/e418e173-b08c-4da6-ae44-0aefe9f2817a)



### QA

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | &ndash;
