### PR TITLE
Fixed website relation for nav container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ In order to read more about upgrading and BC breaks have a look at the [UPGRADE 
 
 ## 5.1.1
 
++ [#412](https://github.com/luyadev/luya-module-cms/pull/412) Fixed website relation for nav container (when accessing `navContainer->website`).
 + [#410](https://github.com/luyadev/luya-module-cms/pull/410) Disabled sorting functionality for the "group" extra field in the block CRUD interface due to an exception being thrown. This issue occurred because the field is declared as an `extraAttribute`.
 + [#409](https://github.com/luyadev/luya-module-cms/issues/409) Implemented a new validation check to prevent slug duplication within the same language and navigation hierarchy when creating a new page. This enhancement ensures unique page identification and avoids conflicts in site structure.
 

--- a/src/models/NavContainer.php
+++ b/src/models/NavContainer.php
@@ -11,6 +11,7 @@ use yii\db\ActiveQuery;
 /**
  * Navigation-Containers Model.
  *
+ * @property integer $id
  * @property string $name
  * @property string $alias
  * @property integer $website_id
@@ -58,7 +59,7 @@ class NavContainer extends NgRestModel
     {
         return [
             [['name', 'alias', 'website_id'], 'required'],
-            [['website_id', 'is_deleted', 'website_id'], 'integer'],
+            [['website_id'], 'integer'],
             [['is_deleted'], 'boolean']
         ];
     }
@@ -113,6 +114,6 @@ class NavContainer extends NgRestModel
      */
     public function getWebsite()
     {
-        return $this->hasOne(Website::class, ['website_id' => 'id']);
+        return $this->hasOne(Website::class, ['id' => 'website_id']);
     }
 }

--- a/tests/src/models/NavContainerTest.php
+++ b/tests/src/models/NavContainerTest.php
@@ -46,6 +46,11 @@ class NavContainerTest extends CmsFrontendTestCase
 
             $this->assertEquals(2, $navContainer->website_id);
             $this->assertSame('test container', $navContainer->name);
+
+            $website = $navContainer->website;
+
+            $this->assertEquals(2, $website->id);
+            $this->assertSame('test', $website->name);
         });
     }
 }


### PR DESCRIPTION
### What are you changing/introducing

- Fixed website relation for nav container in `NavContainer::getWebsite()`
- Therefore enhanced the corresponding unit test in `NavContainerTest::testFindWebsiteContainer()`
- BTW fixed multiple specifications in `rules()` (added in https://github.com/luyadev/luya-module-cms/commit/cc989417efb1801522cac226f41d685d7afc8ea0)
  - https://github.com/luyadev/luya-module-cms/blob/2138decfd1353e20059a3df571cbfa2017d0caa0/src/models/NavContainer.php#L61-L62

### What is the reason for changing/introducing

- SQL error when accessing `navContainer->website`:
```
SQLSTATE[42S22]: Column not found: 1054 Unknown column 'website_id' in 'where clause'
The SQL being executed was: SELECT * FROM `cms_website` WHERE (`cms_website`.`is_deleted`=FALSE) AND (`website_id`=1)
```
- The reason was that the column names passed in `hasOne()` are accidentally swapped:
  - https://github.com/luyadev/luya-module-cms/blob/2138decfd1353e20059a3df571cbfa2017d0caa0/src/models/NavContainer.php#L116




### QA

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | &ndash;
