### PR TITLE
Fixed navItem relation for inactive page versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ In order to read more about upgrading and BC breaks have a look at the [UPGRADE 
 
 ## 5.1.1
 
++ [#415](https://github.com/luyadev/luya-module-cms/pull/415) Fixed navItem relation for inactive page versions.
 + [#412](https://github.com/luyadev/luya-module-cms/pull/412) Fixed website relation for nav container (when accessing `navContainer->website`).
 + [#410](https://github.com/luyadev/luya-module-cms/pull/410) Disabled sorting functionality for the "group" extra field in the block CRUD interface due to an exception being thrown. This issue occurred because the field is declared as an `extraAttribute`.
 + [#409](https://github.com/luyadev/luya-module-cms/issues/409) Implemented a new validation check to prevent slug duplication within the same language and navigation hierarchy when creating a new page. This enhancement ensures unique page identification and avoids conflicts in site structure.

--- a/src/base/NavItemType.php
+++ b/src/base/NavItemType.php
@@ -32,7 +32,7 @@ abstract class NavItemType extends ActiveRecord implements NavItemTypeInterface
      */
     public function getNavItem()
     {
-        return $this->hasOne(NavItem::class, ['nav_item_type_id' => 'id'])->where(['nav_item_type' => static::getNummericType()]);
+        return $this->hasOne(NavItem::class, ['id' => 'nav_item_id'])->where(['nav_item_type' => static::getNummericType()]);
     }
 
     /**

--- a/src/base/NavItemType.php
+++ b/src/base/NavItemType.php
@@ -32,7 +32,7 @@ abstract class NavItemType extends ActiveRecord implements NavItemTypeInterface
      */
     public function getNavItem()
     {
-        return $this->hasOne(NavItem::class, ['id' => 'nav_item_id'])->where(['nav_item_type' => static::getNummericType()]);
+        return $this->hasOne(NavItem::class, ['nav_item_type_id' => 'id'])->where(['nav_item_type' => static::getNummericType()]);
     }
 
     /**

--- a/src/models/NavItemPage.php
+++ b/src/models/NavItemPage.php
@@ -576,6 +576,14 @@ class NavItemPage extends NavItemType implements NavItemTypeInterface, ViewConte
     }
 
     /**
+     * {@inheritdoc}
+     */
+    public function getNavItem()
+    {
+        return $this->hasOne(NavItem::class, ['id' => 'nav_item_id'])->where(['nav_item_type' => static::getNummericType()]);
+    }
+
+    /**
      * This method is used to force the parent nav item for the corresponding page item whether the type matches or not:
      *
      * @return \luya\cms\models\NavItem

--- a/tests/src/models/NavItemPageTest.php
+++ b/tests/src/models/NavItemPageTest.php
@@ -3,6 +3,7 @@
 namespace NavItemPageTest;
 
 use cmstests\WebModelTestCase;
+use luya\cms\models\NavItem;
 use luya\cms\models\NavItemPage;
 use luya\testsuite\fixtures\NgRestModelFixture;
 use luya\testsuite\traits\CmsDatabaseTableTrait;
@@ -106,5 +107,45 @@ class NavItemPageTest extends WebModelTestCase
         } catch (\Exception $e) {
             $this->assertStringContainsString('views/cmslayouts'.DIRECTORY_SEPARATOR.'relative.php', $e->getMessage());
         }
+    }
+
+    public function testNavItemForPageVersions()
+    {
+        $navItemFixture = $this->createCmsNavItemFixture([
+            1 => [
+                'id' => 1,
+                'nav_id' => 11,
+                'alias' => 'foobar',
+                'nav_item_type' => 1,
+                'nav_item_type_id' => 2,
+            ]
+        ]);
+
+        $pageFixture = $this->createCmsNavItemPageFixture([
+            'version1' => [
+                'id' => 1,
+                'nav_item_id' => 1,
+                'version_alias' => 'first',
+            ],
+            'version2' => [
+                'id' => 2,
+                'nav_item_id' => 1,
+                'version_alias' => 'second',
+            ]
+        ]);
+
+        $navItem = $navItemFixture->getModel(1);
+        $pageVersion1 = $pageFixture->getModel('version1'); // inactive page version
+        $pageVersion2 = $pageFixture->getModel('version2'); // active page version
+
+        $this->assertInstanceOf(NavItem::class, $pageVersion1->navItem);
+        $this->assertSame(1, $pageVersion1->navItem->id);
+        $this->assertSame(11, $pageVersion1->navItem->nav_id);
+        $this->assertSame('foobar', $pageVersion1->navItem->alias);
+
+        $this->assertInstanceOf(NavItem::class, $pageVersion2->navItem);
+        $this->assertSame(1, $pageVersion2->navItem->id);
+        $this->assertSame(11, $pageVersion2->navItem->nav_id);
+        $this->assertSame('foobar', $pageVersion2->navItem->alias);
     }
 }


### PR DESCRIPTION
### What are you changing/introducing

- Fixed `navItem` relation for ~~`NavItemType`~~ `NavItemPage`
  - by overriding `getNavItem()` and therein changing relation from "reverse" direction`hasOne(..., navItemFK => navItemTypePK)` into `hasOne(..., navItemPK => navItemTypeFK)`

### What is the reason for changing/introducing

- `navItem` was missing for inactive page versions


### QA

| Q             | A
| ------------- | ---
| Is bugfix?    | yes
| New feature?  | no
| Breaks BC?    | no
| Tests pass?   | yes
| Fixed issues  | Closes #414
