### PR TITLE
Added new block's page property

### DIFF
--- a/src/base/BlockInterface.php
+++ b/src/base/BlockInterface.php
@@ -98,6 +98,20 @@ interface BlockInterface
     public function getFieldHelp();
 
     /**
+     * Set the block's {{luya\cms\models\NavItemPage}} object.
+     * 
+     * @param NavItemPage $page The page object.
+     */
+    public function setPage($page);
+
+    /**
+     * Returns the block's {{luya\cms\models\NavItemPage}} object.
+     * 
+     * @return NavItemPage
+     */
+    public function getPage();
+
+    /**
      * Set an environment option informations to the block with key value pairing.
      *
      * @param string $key The identifier key.

--- a/src/base/BlockInterface.php
+++ b/src/base/BlockInterface.php
@@ -99,14 +99,14 @@ interface BlockInterface
 
     /**
      * Set the block's {{luya\cms\models\NavItemPage}} object.
-     * 
+     *
      * @param NavItemPage $page The page object.
      */
     public function setPage($page);
 
     /**
      * Returns the block's {{luya\cms\models\NavItemPage}} object.
-     * 
+     *
      * @return NavItemPage
      */
     public function getPage();

--- a/src/base/InternalBaseBlock.php
+++ b/src/base/InternalBaseBlock.php
@@ -12,10 +12,10 @@ use yii\base\BaseObject;
 use yii\helpers\Inflector;
 
 /**
- * Concret Block implementation based on BlockInterface.
+ * Concrete Block implementation based on BlockInterface.
  *
- * This is an use case for the block implemenation as InternBaseBlock fro
- * two froms of implementations.
+ * This is an use case for the block implementation as InternBaseBlock for
+ * two forms of implementations.
  *
  * + {{\luya\cms\base\PhpBlock}}
  *
@@ -288,6 +288,24 @@ abstract class InternalBaseBlock extends BaseObject implements BlockInterface, T
     public function isFrontendContext()
     {
         return ($this->getEnvOption('context', false) === 'frontend') ? true : false;
+    }
+
+    private $_page;
+
+    /**
+     * @inheritdoc
+     */
+    public function setPage($page)
+    {
+        $this->_page = $page;
+    }
+
+    /**
+     * @inheritdoc
+     */
+    public function getPage()
+    {
+        return $this->_page;
     }
 
     private array $_envOptions = [];

--- a/src/base/PhpBlockView.php
+++ b/src/base/PhpBlockView.php
@@ -162,10 +162,25 @@ class PhpBlockView extends View
      *
      * @return \luya\cms\models\NavItemPage
      * @since 1.0.2
+     * @deprecated 5.2.0
+     * @see getPage()
      */
     public function getPageObject()
     {
         return $this->context->getEnvOption('pageObject');
+    }
+
+    /**
+     * Returns the context {{luya\cms\models\NavItemPage}} object.
+     *
+     * Returns the context page object where the block is implemented.
+     *
+     * @return \luya\cms\models\NavItemPage
+     * @since 5.2.0
+    */
+    public function getPage()
+    {
+        return $this->context->getPage();
     }
 
     /**
@@ -174,7 +189,7 @@ class PhpBlockView extends View
      * + **id**: Returns the unique identifier for this block, each blocks has its id from the database, this is absolute unique. {{luya\cms\models\NavItemPageBlockItem}} -> id
      * + **blockId**: Returns the id of the block in the database. Two blocks of the same type would have the same blockId. {{luya\cms\models\Block}} -> id
      * + **context**: Returns `frontend` or `admin` to find out in which context you are.
-     * + **pageObject**: Returns the {{luya\cms\models\NavItemPage}} object where the block is located. Thereof you can also retrieve the related {{luya\cms\models\NavItem}} and {{luya\cms\models\Nav}} objects via `getNavItem()` and `getNav()`.
+     * + **pageObject**: Returns the {{luya\cms\models\NavItemPage}} object where the block is located. Thereof you can also retrieve the related {{luya\cms\models\NavItem}} and {{luya\cms\models\Nav}} objects via `getNavItem()` and `getNav()` (deprecated since 5.2.0).
      * + **isFirst**: Returns whether this block is the first in its placeholder or not.
      * + **isLast**: Returns whether this block is the last in its placeholder or not.
      * + **index**: Returns the index number/position within this placeholder.

--- a/src/models/Block.php
+++ b/src/models/Block.php
@@ -281,7 +281,9 @@ class Block extends NgRestModel
         $object->setEnvOption('id', $id);
         $object->setEnvOption('blockId', $blockId);
         $object->setEnvOption('context', $context);
-        $object->setEnvOption('pageObject', $pageObject);
+        $object->setEnvOption('pageObject', $pageObject); // deprecated since 5.2.0
+        
+        $object->setPage($pageObject);
 
         $object->setup();
 

--- a/src/models/Block.php
+++ b/src/models/Block.php
@@ -282,7 +282,7 @@ class Block extends NgRestModel
         $object->setEnvOption('blockId', $blockId);
         $object->setEnvOption('context', $context);
         $object->setEnvOption('pageObject', $pageObject); // deprecated since 5.2.0
-        
+
         $object->setPage($pageObject);
 
         $object->setup();

--- a/tests/data/blocks/ConcreteImplementationBlock.php
+++ b/tests/data/blocks/ConcreteImplementationBlock.php
@@ -5,7 +5,7 @@ namespace cmstests\data\blocks;
 use luya\cms\base\BlockInterface;
 use luya\cms\frontend\blockgroups\DevelopmentGroup;
 
-class ConcretImplementationBlock implements BlockInterface
+class ConcreteImplementationBlock implements BlockInterface
 {
     public function onRegister()
     {
@@ -92,6 +92,28 @@ class ConcretImplementationBlock implements BlockInterface
     public function getFieldHelp()
     {
         return [];
+    }
+
+    private $_page;
+
+    /**
+     * Set the block's {{luya\cms\models\NavItemPage}} object.
+     *
+     * @param NavItemPage $page The page object.
+     */
+    public function setPage($page)
+    {
+        $this->_page = $page;
+    }
+
+    /**
+     * Returns the block's {{luya\cms\models\NavItemPage}} object.
+     *
+     * @return NavItemPage
+     */
+    public function getPage()
+    {
+        return $this->_page;
     }
 
     private $_envs = [];

--- a/tests/src/base/InternalBaseBlockTest.php
+++ b/tests/src/base/InternalBaseBlockTest.php
@@ -8,9 +8,9 @@ use luya\helpers\Html;
 
 class InternalBaseBlockTest extends CmsFrontendTestCase
 {
-    public function testConcretImplementation()
+    public function testConcreteImplementation()
     {
-        $object = new ConcretImplementationBlock();
+        $object = new ConcreteImplementationBlock();
 
         $this->assertInstanceOf('luya\cms\base\BlockInterface', $object);
     }

--- a/tests/src/base/PhpBlockViewTest.php
+++ b/tests/src/base/PhpBlockViewTest.php
@@ -3,7 +3,7 @@
 namespace cmstests\src\base;
 
 use cmstests\CmsFrontendTestCase;
-use cmstests\data\blocks\ConcretImplementationBlock;
+use cmstests\data\blocks\ConcreteImplementationBlock;
 use cmstests\data\blocks\PhpTestBlock;
 use luya\cms\base\PhpBlockView;
 use luya\web\View;
@@ -127,11 +127,11 @@ class PhpBlockViewTest extends CmsFrontendTestCase
 
     public function testGetBlock()
     {
-        $block = new ConcretImplementationBlock();
+        $block = new ConcreteImplementationBlock();
         $view = new PhpBlockView();
         $view->context = $block;
 
-        $this->assertInstanceOf(ConcretImplementationBlock::class, $view->getBlock());
+        $this->assertInstanceOf(ConcreteImplementationBlock::class, $view->getBlock());
     }
 
     public function testGetters()


### PR DESCRIPTION
### What are you changing/introducing

- Added `page` property for blocks in both admin and frontend context as a replacement for `getEnvOption('pageObject')`, which is now deprecated
- Fixed typo in test names:
  - `ConcretImplementationBlock` &rarr; `ConcreteImplementationBlock`
  - `testConcretImplementation() `&rarr; `testConcreteImplementation()`
- New unit tests will be come.... please let the PR open 

### What is the reason for changing/introducing
 
- see https://github.com/luyadev/luya-module-cms/issues/414#issuecomment-1980312072


### QA

| Q             | A
| ------------- | ---
| Is bugfix?    | no
| New feature?  | yes
| Breaks BC?    | no (env option `'pageObject'` is set deprecated)
| Tests pass?   | yes
| Fixed issues  | &ndash;